### PR TITLE
docs: improve Dockerfile organization and add environment setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# Azure/Entra Credentials
+# Get these from your Azure App Registration
+AZURE_CLIENT_ID=
+AZURE_CLIENT_SECRET=
+AZURE_TENANT_ID=
+
+# Bloodhound API Credentials
+# Generate these after initial setup (see README step 6)
+BLOODHOUND_TOKEN_KEY=
+BLOODHOUND_TOKEN_ID=
+
+# Optional: Bloodhound Configuration
+# BLOODHOUND_ENDPOINT=http://bloodhound:8080
+# BLOODHOUND_HOST=127.0.0.1
+# BLOODHOUND_PORT=8080
+# BLOODHOUND_TAG=latest
+
+# Optional: PostgreSQL Configuration
+# POSTGRES_USER=bloodhound
+# POSTGRES_PASSWORD=bloodhoundcommunityedition
+# POSTGRES_DB=bloodhound
+# POSTGRES_PORT=5432
+
+# Optional: Neo4j Configuration
+# NEO4J_USER=neo4j
+# NEO4J_SECRET=bloodhoundcommunityedition
+# NEO4J_DB_PORT=7687
+# NEO4J_WEB_PORT=7474
+# NEO4J_ALLOW_UPGRADE=true
+
+# Optional: Bloodhound Advanced Settings
+# bhe_disable_cypher_complexity_limit=false
+# bhe_enable_cypher_mutations=false
+# bhe_graph_query_memory_limit=2
+# bhe_recreate_default_admin=false
+# bhe_enable_text_logger=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .venv/
+.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,39 @@
-FROM --platform=linux/amd64 ubuntu:latest
+FROM --platform=linux/amd64 ubuntu:22.04
 
 WORKDIR /app
 
-RUN apt update && \
-    apt install -y zip unzip wget python3 python3-pip python3-venv
+# Install dependencies and clean up in one layer
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  wget \
+  unzip \
+  python3 \
+  python3-pip \
+  python3-venv \
+  ca-certificates \
+  dos2unix && \
+  rm -rf /var/lib/apt/lists/*
 
+# NOTE: Copy and update CA certificates (uncomment if needed for corporate environments)
+# See README for instructions on adding custom certificates
+# COPY <certfile> /usr/local/share/ca-certificates/
+# RUN update-ca-certificates
+
+# Setup Python virtual environment
 RUN python3 -m venv .venv
 
+# Install Python dependencies (cached unless requirements.txt changes)
 COPY requirements.txt .
+RUN dos2unix requirements.txt && \
+  .venv/bin/pip install --no-cache-dir -r requirements.txt
 
-RUN .venv/bin/pip install -r requirements.txt
+# Download and extract AzureHound in one layer
+RUN wget -q https://github.com/SpecterOps/AzureHound/releases/download/v2.4.1/AzureHound_v2.4.1_linux_amd64.zip && \
+  unzip -q AzureHound_v2.4.1_linux_amd64.zip && \
+  rm AzureHound_v2.4.1_linux_amd64.zip
 
-COPY ingestdata.py .
+# Copy application files and fix line endings
+COPY ingestdata.py update.sh ./
+RUN dos2unix ingestdata.py update.sh
 
-COPY update.sh .
-
-RUN wget https://github.com/SpecterOps/AzureHound/releases/download/v2.4.1/AzureHound_v2.4.1_linux_amd64.zip
-
-RUN unzip AzureHound_v2.4.1_linux_amd64.zip
-
-RUN rm AzureHound_v2.4.1_linux_amd64.zip
-
-CMD ["bash", "-c", "bash update.sh"]
+CMD ["bash", "update.sh"]

--- a/README.md
+++ b/README.md
@@ -19,30 +19,75 @@ for Bloodhound provided by [SpectreOps](https://bloodhound.specterops.io/get-sta
   - `BLOODHOUND_TOKEN_ID` (after initial setup, see below)
 - Docker or Docker Desktop
 
+### Corporate Environment / Custom CA Certificates
+
+If you're in a corporate environment where a firewall is intercepting and
+resigning SSL/TLS requests, you'll need to add your custom CA certificate(s)
+to the Docker image:
+
+1. Place your certificate file(s) (`.crt` format) in the repository directory
+2. Edit the `Dockerfile` and uncomment the certificate lines (around line 17-20):
+
+   ```dockerfile
+   # COPY <certfile> /usr/local/share/ca-certificates/
+   # RUN update-ca-certificates
+   ```
+
+3. Replace `<certfile>` with your certificate filename(s). For multiple certificates:
+
+   ```dockerfile
+   COPY cert1.crt cert2.crt /usr/local/share/ca-certificates/
+   RUN update-ca-certificates
+   ```
+
+4. Rebuild the image and recreate the container:
+
+   ```bash
+   docker compose up -d --build azurehound
+   ```
+
+   This will rebuild the image with your certificates and recreate the container.
+
 ## Getting Started
 
 1. Clone this repo
-2. Set up your `.env` file with the required environment variables:
+2. Copy the example environment file and configure it:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Edit `.env` and add your Azure/Entra credentials:
+
    - `AZURE_CLIENT_ID`
    - `AZURE_CLIENT_SECRET`
    - `AZURE_TENANT_ID`
-3. Execute `docker compose up -d` to start the Bloodhound services (app-db,
-   graph-db, and bloodhound)
-4. Access the bloodhound instance at `http://localhost:8080/ui/login`
-5. Login as `admin`, the default password can be found in `bloodhound.config.json`
-6. Create a new user (optional) and generate an API key and ID, see:
+
+4. Execute `docker compose up -d` to start the Bloodhound services (app-db,
+   graph-db, and bloodhound - azurehound will fail that is OK)
+
+5. Access the bloodhound instance at `http://localhost:8080/ui/login`
+
+6. Login as `admin`, the default password can be found in `bloodhound.config.json`
+
+7. Create a new user (optional) and generate an API key and ID, see:
    [Create a non-personal API key/ID pair](https://bloodhound.specterops.io/integrations/bloodhound-api/working-with-api#create-a-non-personal-api-key%2Fid-pair).
-7. Add the following environment variables to your `.env` file:
+
+8. Add/Update the following environment variables to your `.env` file:
+
    - `BLOODHOUND_TOKEN_KEY` (the API key you generated)
    - `BLOODHOUND_TOKEN_ID` (the API ID you generated)
-8. Execute `docker compose up -d --force-recreate
-9. The `azurehound` container will automatically run and:
-   - Collect data from the target Entra and Azure environment
-   - Generate an `output.json` file with the collected data
-   - Upload the data to the Bloodhound instance via the API
-   - Exit after completion (this is expected behavior)
 
-> [!NOTE]
+9. Execute `docker compose up -d --force-recreate azurehound`
+
+10. The `azurehound` container will automatically run and:
+
+    - Collect data from the target Entra and Azure environment
+    - Generate an `output.json` file with the collected data
+    - Upload the data to the Bloodhound instance via the API
+    - Exit after completion (this is expected behavior)
+
+> [!TIP]
 > You can start the `azurehound` container to refetch data from Entra and Azure
 > on demand
 
@@ -58,20 +103,38 @@ To refresh the data with current information from Azure/Entra:
 1. Execute `docker compose up azurehound` to re-run the azurehound container
 2. The container will collect fresh data and upload it to Bloodhound
 
-> [!Note]
+> [!IMPORTANT]
 > This will add to the existing data set rather than replacing it. This can result
-> in duplicate data - you way wish to instead wipe the data and refresh it.
+> in duplicate data - you way wish to instead wipe the data and refresh it. See
+> the next section.
 
 ### Wiping the database
 
-To completely wipe the database and start fresh, delete the neo4j volume. The
-easiest way is to take down the compose project _with_ the volumes. This will
-delete the volumes creates by compose alongside the containers. Then simply run
-compose again.
+To completely wipe the neo4j database and start fresh:
 
-1. Execute `docker compose down --volumes`
-2. Execute `docker compose up -d` to spin up the containers
+#### Option 1: Stop only the graph database and remove its volume
 
-Docker will recreate the neo4j volume, and the `azurehound` container will fetch
-fresh data from your Entra and Azure environments and upload it to your Bloodhound
-instance, which will then write the data into the fresh neo4j database.
+```bash
+docker compose stop graph-db
+docker volume rm bloodhound_neo4j-data
+docker compose up -d graph-db
+```
+
+#### Option 2: Take down everything with volumes (nuclear option)
+
+```bash
+docker compose down --volumes
+docker compose up -d
+```
+
+After wiping the database, run the azurehound container to populate it with
+fresh data:
+
+```bash
+docker compose up azurehound
+```
+
+> [!TIP]
+> Option 1 is recommended as it only affects the neo4j database, keeping your
+> Bloodhound configuration and postgres data intact. Option 2 will reset everything
+> including user accounts and settings.


### PR DESCRIPTION
- Optimize Dockerfile with better layer caching and reduced image size
- Pin Ubuntu version to 22.04 instead of using latest
- Combine RUN commands to reduce layers
- Add corporate certificate support (commented out by default)
- Create .env.example with all configuration options
- Update README with detailed setup instructions including .env usage
- Add database wipe options (targeted vs nuclear approaches)